### PR TITLE
Write next steps before scheduler run

### DIFF
--- a/reconx/reconx/__main__.py
+++ b/reconx/reconx/__main__.py
@@ -74,11 +74,11 @@ def cmd_run(args):
         key = (a.tool, json.dumps(a.args, sort_keys=True), a.target)
         ded[key] = a
     planned = list(ded.values())
-        with (out / 'next_steps.md').open('w', encoding='utf-8') as f:
-            f.write('# Next Steps\n\n')
-            for a in planned:
-                f.write(f"- [{a.priority}] {a.tool} on {a.target} with {a.args}\n")
-        
+    with (out / 'next_steps.md').open('w', encoding='utf-8') as f:
+        f.write('# Next Steps\n\n')
+        for a in planned:
+            f.write(f"- [{a.priority}] {a.tool} on {a.target} with {a.args}\n")
+
     run_scheduler(out, planned, time_budget_minutes=int(args.time_budget or 0) or budget,
                   max_parallel=int(args.max_parallel or 1),
                   timeout_per_task=int(args.timeout or 600),

--- a/reconx/tests/test_cmd_run.py
+++ b/reconx/tests/test_cmd_run.py
@@ -1,0 +1,45 @@
+from argparse import Namespace
+import json
+from pathlib import Path
+
+from reconx.__main__ import cmd_run
+
+
+def test_cmd_run_creates_next_steps(tmp_path: Path, monkeypatch):
+    scope = {
+        "targets": ["1.2.3.4"],
+        "allowed_tools": ["layer1"],
+        "time_budget_minutes": 5,
+    }
+    scope_path = tmp_path / "scope.json"
+    scope_path.write_text(json.dumps(scope))
+    out_dir = tmp_path / "out"
+
+    called = {}
+
+    def fake_run_scheduler(out, planned, time_budget_minutes, max_parallel, timeout_per_task, rate_per_sec):
+        assert (out / "next_steps.md").exists()
+        called["called"] = True
+
+    monkeypatch.setenv("AUTH_OK", "1")
+    monkeypatch.setattr("reconx.__main__.run_scheduler", fake_run_scheduler)
+    monkeypatch.setattr("reconx.__main__.plan_actions", lambda *args, **kwargs: [])
+
+    args = Namespace(
+        target="1.2.3.4",
+        scope=str(scope_path),
+        out=str(out_dir),
+        layers="1",
+        plan="auto",
+        rules=None,
+        max_parallel=1,
+        timeout=10,
+        rate=0.0,
+        time_budget=1,
+    )
+
+    cmd_run(args)
+
+    assert (out_dir / "next_steps.md").exists()
+    assert called.get("called")
+

--- a/reconx/tests/test_scheduler.py
+++ b/reconx/tests/test_scheduler.py
@@ -3,11 +3,15 @@ import os, json
 from reconx.scheduler import run_scheduler
 from reconx.model import Action
 
+
 def test_scheduler_runs_layer(tmp_path: Path):
     # Create dummy layer1 script
     script = tmp_path / "recon_layer1.sh"
-    script.write_text("#!/usr/bin/env bash\nmkdir -p \"$OUT/layer1\"\n" +
-                      "echo '{\"layer\":1,\"target\":"'$T'\"}' > \"$OUT/layer1/summary.json\"\n")
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "mkdir -p \"$OUT/layer1\"\n"
+        "echo '{\"layer\":1,\"target\":\"'$T'\"}' > \"$OUT/layer1/summary.json\"\n"
+    )
     os.chmod(script, 0o755)
     out_dir = tmp_path / "OUT"
     out_dir.mkdir()
@@ -23,3 +27,4 @@ def test_scheduler_runs_layer(tmp_path: Path):
         assert comb
     finally:
         os.chdir(cwd)
+


### PR DESCRIPTION
## Summary
- Ensure `cmd_run` writes `next_steps.md` before starting the scheduler
- Add regression test exercising `cmd_run` to confirm `next_steps.md` creation
- Fix quoting in scheduler test script setup

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ea97219c832ba21df40f6f1d0ec4