### PR TITLE
Parse Nmap XML for hosts and services

### DIFF
--- a/reconx/fixtures/nmap_basic.xml
+++ b/reconx/fixtures/nmap_basic.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun>
+  <host>
+    <status state="up" />
+    <address addr="192.0.2.1" addrtype="ipv4" />
+    <ports>
+      <port protocol="tcp" portid="22">
+        <state state="open" />
+        <service name="ssh" product="OpenSSH" version="7.9" />
+      </port>
+      <port protocol="tcp" portid="80">
+        <state state="open" />
+        <service name="http" product="Apache httpd" version="2.4.41" />
+      </port>
+    </ports>
+  </host>
+</nmaprun>

--- a/reconx/reconx/parsers/nmap.py
+++ b/reconx/reconx/parsers/nmap.py
@@ -1,6 +1,62 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, List
+from xml.etree import ElementTree as ET
+
 
 def parse_nmap_xml(xml_path: Path) -> Dict[str, Any]:
-    return {"parsed": False, "path": str(xml_path)}
+    """Parse an Nmap XML output file.
+
+    The returned dictionary contains a ``hosts`` key where each host has its
+    IPv4 address and a list of ``ports``.  Each port entry includes common
+    service information so that callers can easily convert the results into a
+    :class:`~reconx.model.SummaryModel` ``Evidence`` object.
+
+    Parameters
+    ----------
+    xml_path:
+        Path to the Nmap XML file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Structured data describing hosts, ports and services.
+    """
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    hosts: List[Dict[str, Any]] = []
+    for host in root.findall("host"):
+        addr_elem = host.find("address[@addrtype='ipv4']")
+        if addr_elem is None:
+            # Skip hosts without an IPv4 address
+            continue
+        host_dict: Dict[str, Any] = {"address": addr_elem.get("addr"), "ports": []}
+
+        ports_elem = host.find("ports")
+        if ports_elem is not None:
+            for port in ports_elem.findall("port"):
+                port_dict: Dict[str, Any] = {
+                    "port": int(port.get("portid", 0)),
+                    "proto": port.get("protocol"),
+                }
+
+                state_elem = port.find("state")
+                if state_elem is not None:
+                    port_dict["state"] = state_elem.get("state")
+
+                service_elem = port.find("service")
+                if service_elem is not None:
+                    if service_elem.get("name"):
+                        port_dict["service"] = service_elem.get("name")
+                    if service_elem.get("product"):
+                        port_dict["product"] = service_elem.get("product")
+                    if service_elem.get("version"):
+                        port_dict["version"] = service_elem.get("version")
+
+                host_dict["ports"].append(port_dict)
+
+        hosts.append(host_dict)
+
+    return {"hosts": hosts}

--- a/reconx/tests/test_nmap_parser.py
+++ b/reconx/tests/test_nmap_parser.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from reconx.parsers import parse_nmap_xml
+
+
+def test_parse_basic_nmap_xml():
+    xml_path = Path(__file__).resolve().parent.parent / "fixtures" / "nmap_basic.xml"
+    result = parse_nmap_xml(xml_path)
+
+    assert "hosts" in result
+    assert len(result["hosts"]) == 1
+
+    host = result["hosts"][0]
+    assert host["address"] == "192.0.2.1"
+    assert len(host["ports"]) == 2
+
+    ports = {p["port"]: p for p in host["ports"]}
+    assert ports[22]["service"] == "ssh"
+    assert ports[80]["service"] == "http"
+    assert ports[80]["product"] == "Apache httpd"
+    assert ports[22]["product"] == "OpenSSH"


### PR DESCRIPTION
## Summary
- expand Nmap parser to extract hosts, ports, and service info from XML
- add sample Nmap XML fixture and accompanying unit test

## Testing
- `pytest tests/test_nmap_parser.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ea99f8f4832ba08e0b2c7f6bae43