### PR TITLE
Add DNS enumeration and TLS probing handlers

### DIFF
--- a/reconx/README.md
+++ b/reconx/README.md
@@ -31,6 +31,15 @@ python -m reconx resume --target 1.2.3.4 --scope examples/scope.json --out ./enu
 }
 ```
 
+## Built-in Tools
+
+ReconX ships with several lightweight adapters to kickstart common recon tasks:
+
+- `http_enum` – retrieve basic HTTP headers for a target URL.
+- `ssh_banner` – grab SSH server banners to identify versions.
+- `dns_enum` – query common DNS record types such as `A`, `AAAA`, `MX`, `TXT` and `NS`.
+- `tls_probe` – connect with OpenSSL to collect certificate metadata.
+
 ## Summary JSON Schema (emitted by each layer)
 ```json
 {
@@ -62,6 +71,20 @@ YAML rule format (see `examples/rules.yaml`):
           tech_fingerprinting: true
     rationale: "Web service discovered; enumerate endpoints/tech"
     max_parallel: 2
+- match: "evidence[type=='service' and service=='dns']"
+  then:
+    run:
+      - tool: "dns_enum"
+        with:
+          record_types: ["A","AAAA","MX","TXT","NS"]
+    rationale: "DNS service present; enumerate basic records"
+- match: "evidence[type=='service' and service in ['http','https']]"
+  then:
+    run:
+      - tool: "tls_probe"
+        with:
+          port: "{port}"
+    rationale: "Inspect TLS configuration and certificate details"
 ```
 
 ## Outputs

--- a/reconx/examples/rules.yaml
+++ b/reconx/examples/rules.yaml
@@ -23,7 +23,7 @@
         with:
           grab_timeout: 5
     rationale: "Fingerprint SSH to map versions and ciphers"
-- match: "evidence[type=='service' and service in ['dns'] and port in [53]]"
+- match: "evidence[type=='service' and service=='dns']"
   then:
     run:
       - tool: "dns_enum"
@@ -37,10 +37,10 @@
         with:
           list_shares: true
     rationale: "SMB exposed; list shares and dialects"
-- match: "findings[id=='WEB-TLS-OLD']"
+- match: "evidence[type=='service' and service in ['http','https']]"
   then:
     run:
       - tool: "tls_probe"
         with:
-          ciphers: ["DEFAULT@SECLEVEL=1"]
-    rationale: "Weak TLS indicated; confirm protocols/ciphers"
+          port: "{port}"
+    rationale: "Inspect TLS configuration and certificate details"


### PR DESCRIPTION
## Summary
- add `dns_enum` handler to query basic records via nslookup
- add `tls_probe` handler to collect certificate details
- document new handlers and provide example rules for them

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ea9bb668832b804671b259698329