### PR TITLE
feat(core): add config validation and logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -e .[dev]
+      - run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - run: pytest core/tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core Wi-Fi capture utilities."""

--- a/core/main.py
+++ b/core/main.py
@@ -1,10 +1,23 @@
-# main.py - Warwalker Entry Point
+"""Warwalker entry point."""
+
+import logging
+from pydantic import ValidationError
+
+from core.modules.config import get_settings
 from core.modules.interface_setup import setup_monitor_interface
 from core.modules.scanner import start_scanning
 
+
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    try:
+        get_settings()
+    except ValidationError as exc:
+        logging.error("Invalid configuration: %s", exc)
+        raise SystemExit(1)
+
     iface = setup_monitor_interface()
     if iface:
         start_scanning(iface)
     else:
-        print("No valid external interface found. Exiting.")
+        logging.error("No valid external interface found. Exiting.")

--- a/core/modules/config.py
+++ b/core/modules/config.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    adapter_id: str = Field(..., env="ADAPTER_ID")
+    data_dir: str = Field("./captures", env="DATA_DIR")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached application settings."""
+    return Settings()

--- a/core/modules/interface_setup.py
+++ b/core/modules/interface_setup.py
@@ -1,27 +1,49 @@
-# interface_setup.py - Detects and prepares external WiFi adapter
+"""Detects and prepares external WiFi adapter for monitor mode."""
 
+import logging
 import subprocess
-import os
+from subprocess import CalledProcessError, TimeoutExpired
 
-def setup_monitor_interface():
-    from dotenv import load_dotenv
-    load_dotenv()
+from .config import get_settings
 
-    adapter_id = os.getenv("ADAPTER_ID")
-    result = subprocess.run(["lsusb"], capture_output=True, text=True)
+logger = logging.getLogger(__name__)
 
-    interface_name = None
-    if adapter_id in result.stdout:
-        iw_result = subprocess.run(["iw", "dev"], capture_output=True, text=True)
+
+def _run_cmd(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Execute a subprocess command with error handling."""
+    logger.debug("Running command: %s", " ".join(cmd))
+    return subprocess.run(cmd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def setup_monitor_interface() -> str | None:
+    """Return interface name set to monitor mode or ``None`` on failure."""
+    settings = get_settings()
+    try:
+        result = _run_cmd(["lsusb"], timeout=10)
+    except (CalledProcessError, TimeoutExpired) as exc:
+        logger.error("lsusb failed: %s", exc)
+        return None
+
+    interface_name: str | None = None
+    if settings.adapter_id in result.stdout:
+        try:
+            iw_result = _run_cmd(["iw", "dev"], timeout=10)
+        except (CalledProcessError, TimeoutExpired) as exc:
+            logger.error("iw dev failed: %s", exc)
+            return None
         for line in iw_result.stdout.splitlines():
             if "Interface" in line:
                 interface_name = line.strip().split()[-1]
                 break
         if interface_name:
-            subprocess.run(["sudo", "ip", "link", "set", interface_name, "down"])
-            subprocess.run(["sudo", "iw", interface_name, "set", "monitor", "control"])
-            subprocess.run(["sudo", "ip", "link", "set", interface_name, "up"])
-            print(f"Interface {interface_name} set to monitor mode.")
+            try:
+                subprocess.run(["sudo", "ip", "link", "set", interface_name, "down"], check=True)
+                subprocess.run(["sudo", "iw", interface_name, "set", "monitor", "control"], check=True)
+                subprocess.run(["sudo", "ip", "link", "set", interface_name, "up"], check=True)
+            except CalledProcessError as exc:
+                logger.error("Failed to set monitor mode: %s", exc)
+                return None
+            logger.info("Interface %s set to monitor mode.", interface_name)
             return interface_name
-    print("External adapter not found.")
+    logger.error("External adapter not found.")
     return None

--- a/core/tests/test_config.py
+++ b/core/tests/test_config.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from core.modules.config import get_settings
+
+
+def test_missing_adapter_id(monkeypatch):
+    monkeypatch.delenv("ADAPTER_ID", raising=False)
+    get_settings.cache_clear()
+    with pytest.raises(ValidationError):
+        get_settings()
+
+
+def test_default_data_dir(monkeypatch):
+    monkeypatch.setenv("ADAPTER_ID", "abcd")
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.data_dir == "./captures"

--- a/core/tests/test_interface_setup.py
+++ b/core/tests/test_interface_setup.py
@@ -1,0 +1,40 @@
+import subprocess
+
+import pytest
+
+from core.modules.config import get_settings
+from core.modules.interface_setup import setup_monitor_interface
+
+
+def test_no_adapter(monkeypatch):
+    monkeypatch.setenv("ADAPTER_ID", "abcd")
+    get_settings.cache_clear()
+
+    def fake_run(cmd, **kwargs):
+        class Result:
+            stdout = ""
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert setup_monitor_interface() is None
+
+
+def test_adapter_found(monkeypatch):
+    monkeypatch.setenv("ADAPTER_ID", "abcd")
+    get_settings.cache_clear()
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            stdout = ""
+        if cmd[0] == "lsusb":
+            Result.stdout = "Bus 001 Device 002: ID abcd"
+        elif cmd[:2] == ["iw", "dev"]:
+            Result.stdout = "Interface wlan0"
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert setup_monitor_interface() == "wlan0"
+    assert ["lsusb"] in calls

--- a/core/tests/test_scanner.py
+++ b/core/tests/test_scanner.py
@@ -1,0 +1,25 @@
+import subprocess
+from pathlib import Path
+
+from core.modules.config import get_settings
+from core.modules.scanner import start_scanning
+
+
+def test_start_scanning(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADAPTER_ID", "abcd")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+
+    called = {}
+
+    def fake_run(cmd, **kwargs):
+        called["cmd"] = cmd
+        class Result:
+            pass
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    outfile = start_scanning("wlan0")
+    assert outfile.parent == tmp_path
+    assert called["cmd"][0] == "sudo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "pwnzocchi"
+version = "0.1.0"
+description = "Wi-Fi handshake capture utilities"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.7",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2",
+    "black>=24.4",
+    "ruff>=0.4",
+    "pre-commit>=3.7",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["core/tests"]
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B", "UP"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add pydantic-based settings module for env validation
- log subprocess errors and capture failures in interface setup and scanner
- configure project tooling with pytest, ruff, black, and CI workflow

## Testing
- `pre-commit run --files core/modules/config.py core/modules/interface_setup.py core/modules/scanner.py core/main.py core/tests/test_config.py core/tests/test_interface_setup.py core/tests/test_scanner.py pyproject.toml .pre-commit-config.yaml .github/workflows/ci.yml` *(fails: command not found)*
- `pytest core/tests` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ed98c044832b812711c2a526b208