### PR TITLE
Add modular JSON-based recon pipeline

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,0 +1,43 @@
+# Reconnaissance Pipeline
+
+This directory contains a modular four-layer reconnaissance pipeline. Each layer reads JSON output from the previous layer and writes its own standardized JSON results. Logging and error handling ensure the pipeline is auditable and resilient.
+
+## Layers
+
+1. **Layer 1 – Host Discovery**
+   - Input: target hosts supplied via CLI.
+   - Output: `layer1_output.json`
+   - Fields: `host`, `status`, `timestamp`.
+
+2. **Layer 2 – Port Scanning**
+   - Input: `layer1_output.json`
+   - Output: `layer2_output.json`
+   - Fields: `host`, `port`, `protocol`, `state`, `service`, `timestamp`.
+
+3. **Layer 3 – Service Enumeration**
+   - Input: `layer2_output.json`
+   - Output: `layer3_output.json`
+   - Fields: `host`, `port`, `service`, `banner`, `timestamp`.
+
+4. **Layer 4 – Vulnerability Scan**
+   - Input: `layer3_output.json`
+   - Output: `layer4_output.json`
+   - Fields: `host`, `port`, `vulnerability`, `severity`, `description`, `timestamp`.
+
+## Running the Pipeline
+
+```bash
+# Layer 1
+python layer1.py 192.168.1.1 192.168.1.2
+
+# Layer 2
+python layer2.py --input layer1_output.json --ports 22,80,443
+
+# Layer 3
+python layer3.py --input layer2_output.json
+
+# Layer 4
+python layer4.py --input layer3_output.json
+```
+
+Each script logs its progress and errors to the console with timestamps.

--- a/pipeline/layer1.py
+++ b/pipeline/layer1.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+import logging
+import subprocess
+from datetime import datetime
+from typing import List, Dict
+
+
+def discover_hosts(hosts: List[str]) -> List[Dict[str, str]]:
+    """Ping each host and return discovery results.
+
+    Args:
+        hosts: Iterable of hostnames or IP addresses.
+
+    Returns:
+        List of dictionaries containing host discovery data.
+    """
+    results: List[Dict[str, str]] = []
+    for host in hosts:
+        try:
+            proc = subprocess.run(
+                ["ping", "-c", "1", "-W", "1", host],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            status = "up" if proc.returncode == 0 else "down"
+        except Exception as exc:  # pragma: no cover - network errors not deterministic
+            logging.error("Ping failed for %s: %s", host, exc)
+            status = "down"
+        results.append(
+            {
+                "host": host,
+                "status": status,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Layer 1 - Host Discovery")
+    parser.add_argument(
+        "targets",
+        nargs="+",
+        help="Hosts to probe",
+    )
+    parser.add_argument(
+        "--output",
+        default="layer1_output.json",
+        help="Output JSON file",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    data = discover_hosts(args.targets)
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        logging.info("Layer 1 output written to %s", args.output)
+    except OSError as exc:  # pragma: no cover - filesystem errors are rare
+        logging.error("Failed to write output: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/layer2.py
+++ b/pipeline/layer2.py
@@ -1,0 +1,91 @@
+import argparse
+import json
+import logging
+import socket
+from datetime import datetime
+from typing import List, Dict
+
+
+def load_hosts(path: str) -> List[Dict[str, str]]:
+    """Load layer1 output."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logging.error("Input file %s not found", path)
+    except json.JSONDecodeError as exc:
+        logging.error("Invalid JSON in %s: %s", path, exc)
+    return []
+
+
+def scan_ports(hosts: List[Dict[str, str]], ports: List[int]) -> List[Dict[str, object]]:
+    """Scan ports on hosts that are up."""
+    results: List[Dict[str, object]] = []
+    for entry in hosts:
+        if entry.get("status") != "up":
+            continue
+        host = entry.get("host")
+        for port in ports:
+            state = "closed"
+            service = "unknown"
+            try:
+                with socket.create_connection((host, port), timeout=1) as sock:
+                    state = "open"
+                    try:
+                        service = socket.getservbyport(port, "tcp")
+                    except Exception:
+                        service = "unknown"
+            except Exception:  # pragma: no cover - network conditions vary
+                pass
+            results.append(
+                {
+                    "host": host,
+                    "port": port,
+                    "protocol": "tcp",
+                    "state": state,
+                    "service": service,
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                }
+            )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Layer 2 - Port Scanning")
+    parser.add_argument(
+        "--input",
+        default="layer1_output.json",
+        help="Input JSON from layer 1",
+    )
+    parser.add_argument(
+        "--ports",
+        default="80,443,22",
+        help="Comma separated list of ports to scan",
+    )
+    parser.add_argument(
+        "--output",
+        default="layer2_output.json",
+        help="Output JSON file",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    logging.info("Layer 2 reading input from %s", args.input)
+
+    hosts = load_hosts(args.input)
+    ports = [int(p) for p in args.ports.split(",") if p]
+    results = scan_ports(hosts, ports)
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Layer 2 output written to %s", args.output)
+    except OSError as exc:  # pragma: no cover
+        logging.error("Failed to write output: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/layer3.py
+++ b/pipeline/layer3.py
@@ -1,0 +1,85 @@
+import argparse
+import json
+import logging
+import socket
+from datetime import datetime
+from typing import List, Dict
+
+
+def load_ports(path: str) -> List[Dict[str, object]]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logging.error("Input file %s not found", path)
+    except json.JSONDecodeError as exc:
+        logging.error("Invalid JSON in %s: %s", path, exc)
+    return []
+
+
+def enumerate_services(entries: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    results: List[Dict[str, object]] = []
+    for e in entries:
+        if e.get("state") != "open":
+            continue
+        host = e.get("host")
+        port = e.get("port")
+        service = e.get("service", "unknown")
+        banner = ""
+        try:
+            with socket.create_connection((host, port), timeout=2) as sock:
+                sock.settimeout(2)
+                try:
+                    sock.sendall(b"\r\n")
+                    data = sock.recv(1024)
+                    banner = data.decode(errors="ignore").strip()
+                except Exception:
+                    banner = ""
+        except Exception:  # pragma: no cover - network dependent
+            logging.error("Connection failed for %s:%s", host, port)
+            continue
+        results.append(
+            {
+                "host": host,
+                "port": port,
+                "service": service,
+                "banner": banner,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Layer 3 - Service Enumeration")
+    parser.add_argument(
+        "--input",
+        default="layer2_output.json",
+        help="Input JSON from layer 2",
+    )
+    parser.add_argument(
+        "--output",
+        default="layer3_output.json",
+        help="Output JSON file",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    logging.info("Layer 3 reading input from %s", args.input)
+
+    entries = load_ports(args.input)
+    results = enumerate_services(entries)
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Layer 3 output written to %s", args.output)
+    except OSError as exc:  # pragma: no cover
+        logging.error("Failed to write output: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/layer4.py
+++ b/pipeline/layer4.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+import logging
+from datetime import datetime
+from typing import List, Dict
+
+
+KNOWN_VULNS = [
+    {
+        "pattern": "Apache/2.4.49",
+        "vulnerability": "CVE-2021-41773",
+        "severity": "high",
+        "description": "Path traversal in Apache httpd 2.4.49",
+    },
+    {
+        "pattern": "OpenSSH_7.2",
+        "vulnerability": "CVE-2016-0777",
+        "severity": "medium",
+        "description": "OpenSSH roaming issue",
+    },
+]
+
+
+def load_services(path: str) -> List[Dict[str, object]]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logging.error("Input file %s not found", path)
+    except json.JSONDecodeError as exc:
+        logging.error("Invalid JSON in %s: %s", path, exc)
+    return []
+
+
+def scan_vulnerabilities(entries: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    results: List[Dict[str, object]] = []
+    for e in entries:
+        banner = e.get("banner", "")
+        host = e.get("host")
+        port = e.get("port")
+        for vuln in KNOWN_VULNS:
+            if vuln["pattern"] in banner:
+                results.append(
+                    {
+                        "host": host,
+                        "port": port,
+                        "vulnerability": vuln["vulnerability"],
+                        "severity": vuln["severity"],
+                        "description": vuln["description"],
+                        "timestamp": datetime.utcnow().isoformat() + "Z",
+                    }
+                )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Layer 4 - Vulnerability Scan")
+    parser.add_argument(
+        "--input",
+        default="layer3_output.json",
+        help="Input JSON from layer 3",
+    )
+    parser.add_argument(
+        "--output",
+        default="layer4_output.json",
+        help="Output JSON file",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    logging.info("Layer 4 reading input from %s", args.input)
+
+    services = load_services(args.input)
+    results = scan_vulnerabilities(services)
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Layer 4 output written to %s", args.output)
+    except OSError as exc:  # pragma: no cover
+        logging.error("Failed to write output: %s", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add four-layer reconnaissance pipeline using JSON for data handoff
- implement host discovery, port scan, service enumeration, and basic vuln checks with logging and error handling
- document pipeline usage and data formats

## Testing
- `pip install -e reconx` *(failed: Could not find a version that satisfies the requirement poetry-core)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reconx')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ef6aa8f4832b92ffbded8f453b96