### PR TITLE
fix: import settings from pydantic-settings

### DIFF
--- a/core/modules/config.py
+++ b/core/modules/config.py
@@ -1,5 +1,7 @@
 from functools import lru_cache
-from pydantic import BaseSettings, Field
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -8,9 +10,7 @@ class Settings(BaseSettings):
     adapter_id: str = Field(..., env="ADAPTER_ID")
     data_dir: str = Field("./captures", env="DATA_DIR")
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 @lru_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Wi-Fi handshake capture utilities"
 requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.7",
+    "pydantic-settings>=2.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- switch configuration to use `pydantic-settings`
- add `pydantic-settings` package requirement

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pre-commit run --all-files --show-diff-on-failure --color=always` *(fails: command not found)*
- `pytest core/tests` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a7efc59d48832b9f4f0d3b3e72d4d5