### PR TITLE
Fix capture prefix handling

### DIFF
--- a/core/modules/scanner.py
+++ b/core/modules/scanner.py
@@ -18,6 +18,9 @@ def start_scanning(interface: str) -> Path:
     data_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = data_dir / f"capture_{timestamp}.pcapng"
+    # airodump-ng expects the output prefix without the extension; ``with_suffix``
+    # safely strips the ``.pcapng`` suffix regardless of path complexity.
+    output_prefix = filename.with_suffix("")
     logger.info("Capturing packets on %s into %s", interface, filename)
     try:
         subprocess.run(
@@ -25,7 +28,7 @@ def start_scanning(interface: str) -> Path:
                 "sudo",
                 "airodump-ng",
                 "-w",
-                str(filename).replace(".pcapng", ""),
+                str(output_prefix),
                 "--output-format",
                 "pcapng",
                 interface,

--- a/core/tests/test_scanner.py
+++ b/core/tests/test_scanner.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 from core.modules.config import get_settings
 from core.modules.scanner import start_scanning
@@ -14,8 +13,10 @@ def test_start_scanning(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         called["cmd"] = cmd
+
         class Result:
             pass
+
         return Result()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -23,3 +24,4 @@ def test_start_scanning(monkeypatch, tmp_path):
     outfile = start_scanning("wlan0")
     assert outfile.parent == tmp_path
     assert called["cmd"][0] == "sudo"
+    assert called["cmd"][3] == str(outfile.with_suffix(""))


### PR DESCRIPTION
## Summary
- ensure airodump-ng output prefix is computed using `Path.with_suffix` for safety
- extend scanner test to verify expected prefix

## Testing
- `python -m black --check core/modules/scanner.py core/tests/test_scanner.py`
- `ruff check core/modules/scanner.py core/tests/test_scanner.py`
- `python -m py_compile core/modules/scanner.py core/tests/test_scanner.py`
- ⚠️ `PYTHONPATH=. pytest core/tests/test_scanner.py` *(missing pydantic dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f286abb0832bb8eb30f021cec4fc